### PR TITLE
[repo] Core release 1.9.0-beta.2 updates

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -39,7 +39,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.11.0-beta1.23525.2]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[8.0.0,9.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreLatestVersion>[1.8.1,2.0)</OpenTelemetryCoreLatestVersion>
-    <OpenTelemetryCoreLatestPrereleaseVersion>[1.9.0-alpha.1]</OpenTelemetryCoreLatestPrereleaseVersion>
+    <OpenTelemetryCoreLatestPrereleaseVersion>[1.9.0-beta.2]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.507,2.0)</StyleCopAnalyzersPkgVer>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.9.0-beta.2`.
+  ([#12](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/12))
+
 ## 1.9.0-alpha.1
 
 Released 2024-May-22
@@ -234,7 +237,9 @@ Released 2023-Mar-13
   ([#935](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/935))
 
 * Update OpenTelemetry SDK version to `1.5.0-alpha.1`.
+
 * Update GenevaMetricExporter to use TLV format serialization.
+
 * Add support for exporting exemplars.
   ([#1069](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1069))
 
@@ -286,11 +291,14 @@ Released 2022-Dec-19
 
 * Update OpenTelemetry to 1.4.0-rc.1
   ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+
 * Add support in logs for prefix-based table name mapping configuration.
   [#796](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/796)
+
 * Updated the trace exporter to use the new performance APIs introduced in
   `System.Diagnostics.DiagnosticSource` v7.0.
   [#838](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/838)
+
 * Avoid allocation when serializing scopes.
   ([#818](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/818))
 
@@ -301,10 +309,13 @@ Released 2022-Dec-09
 * Added support for
   [DateTimeOffset](https://learn.microsoft.com/dotnet/api/system.datetimeoffset).
   ([#797](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/797))
+
 * Fix the overflow bucket value serialization for Histogram.
   ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
+
 * Fix EventSource logging.
   ([#813](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/813))
+
 * Update `MessagePackSerializer` to use
   [BinaryPrimitives](https://learn.microsoft.com/dotnet/api/system.buffers.binary.binaryprimitives)
   to serialize scalar types more efficiently by avoiding repeated bound checks.


### PR DESCRIPTION
Note: This PR was opened automatically by the [core version update workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/actions/workflows/core-version-update.yml).

Merge once packages are available on NuGet and the build passes.

## Changes

* Sets `OpenTelemetryCoreLatestPrereleaseVersion` in `Common.props` to `1.9.0-beta.2`.