### PR TITLE
[release] Prepare release Exporter.Geneva-1.10.0-alpha.1

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.10.0-alpha.1
 
-Released 2024-Jun-25
+Released 2024-Jun-28
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.10.0-alpha.1
 
-Released 2024-Jun-28
+Released 2024-Jun-25
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-alpha.1
+
+Released 2024-Jun-28
+
 ## 1.9.0
 
 Released 2024-Jun-21


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/actions/workflows/prepare-release.yml).

Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages and push to NuGet [`approvers`, `maintainers`]