### PR TITLE
[release] core-1.10.0 release updates

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -40,7 +40,7 @@
     <MicrosoftPublicApiAnalyzersPkgVer>[3.11.0-beta1.23525.2]</MicrosoftPublicApiAnalyzersPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[8.0.0,9.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTelemetryCoreUnstableLatestVersion>[1.9.0-beta.2]</OpenTelemetryCoreUnstableLatestVersion>
-    <OpenTelemetryCoreLatestVersion>[1.9.0,2.0)</OpenTelemetryCoreLatestVersion>
+    <OpenTelemetryCoreLatestVersion>[1.10.0,2.0)</OpenTelemetryCoreLatestVersion>
     <OpenTelemetryCoreLatestPrereleaseVersion>[1.9.0-rc.1]</OpenTelemetryCoreLatestPrereleaseVersion>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <CassandraCSharpDriverPkgVer>[3.16.0,4.0)</CassandraCSharpDriverPkgVer>

--- a/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Geneva/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0
 
 Released 2024-Jun-21
@@ -262,7 +265,9 @@ Released 2023-Mar-13
   ([#935](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/935))
 
 * Update OpenTelemetry SDK version to `1.5.0-alpha.1`.
+
 * Update GenevaMetricExporter to use TLV format serialization.
+
 * Add support for exporting exemplars.
   ([#1069](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1069))
 
@@ -314,11 +319,14 @@ Released 2022-Dec-19
 
 * Update OpenTelemetry to 1.4.0-rc.1
   ([#820](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/820))
+
 * Add support in logs for prefix-based table name mapping configuration.
   [#796](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/796)
+
 * Updated the trace exporter to use the new performance APIs introduced in
   `System.Diagnostics.DiagnosticSource` v7.0.
   [#838](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/838)
+
 * Avoid allocation when serializing scopes.
   ([#818](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/818))
 
@@ -329,10 +337,13 @@ Released 2022-Dec-09
 * Added support for
   [DateTimeOffset](https://learn.microsoft.com/dotnet/api/system.datetimeoffset).
   ([#797](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/797))
+
 * Fix the overflow bucket value serialization for Histogram.
   ([#805](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/805))
+
 * Fix EventSource logging.
   ([#813](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/813))
+
 * Update `MessagePackSerializer` to use
   [BinaryPrimitives](https://learn.microsoft.com/dotnet/api/system.buffers.binary.binaryprimitives)
   to serialize scalar types more efficiently by avoiding repeated bound checks.

--- a/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InfluxDB/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-alpha.3
 

--- a/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Instana/CHANGELOG.md
@@ -6,8 +6,8 @@
   The lowest supported version is .NET Framework 4.6.2.
   ([#1050](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1050))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.3
 

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Stackdriver/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-beta.6
 

--- a/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.AWS/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Remove NuGet reference to `System.Net.Http`
   ([#1713](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1713))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Enrichment/CHANGELOG.md
@@ -5,5 +5,5 @@
 * Make Extensions.Enrichment AoT compatible.
   ([#1541](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1541))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))

--- a/src/OpenTelemetry.Extensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Cassandra/CHANGELOG.md
@@ -5,8 +5,8 @@
 * `ActivitySource.Version` is set to NuGet package version.
   ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.ElasticsearchClient/CHANGELOG.md
@@ -12,8 +12,8 @@
   Redact `username` and `password` part of the `url.full`.
   ([#1684](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1684))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-beta.5
 

--- a/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EntityFrameworkCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-beta.12
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.EventCounters/CHANGELOG.md
@@ -5,8 +5,8 @@
 * `Meter.Version` is set to NuGet package version.
   ([#1624](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1624))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.5.1-alpha.1
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-beta.6
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Hangfire/CHANGELOG.md
@@ -8,8 +8,8 @@
 * Update `Microsoft.Extensions.Options` to `8.0.0`.
   ([#1830](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1830))
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.6.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Owin/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.0.0-rc.6
 

--- a/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 0.5.0-beta.6
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Quartz/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-beta.3
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Runtime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.9.0-beta.1
 
 Released 2024-Jun-17

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-rc9.15
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-rc.17
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.AWS/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
 
 ## 1.5.0-beta.1
 

--- a/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Azure/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-beta.8
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.Container/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Container/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 1.0.0-beta.9
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Gcp/CHANGELOG.md
@@ -8,5 +8,5 @@
 
 For more details, please refer to the [README](README.md).
 
-* Updated OpenTelemetry core component version(s) to `1.9.0`.
-  ([#1888](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1888))
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))

--- a/src/OpenTelemetry.Resources.Host/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Host/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 0.1.0-beta.2
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.Process/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.Process/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 0.1.0-beta.2
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
+++ b/src/OpenTelemetry.Resources.ProcessRuntime/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 0.1.0-beta.2
 
 Released 2024-Jun-18

--- a/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
+++ b/src/OpenTelemetry.Sampler.AWS/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated OpenTelemetry core component version(s) to `1.10.0`.
+  ([#26](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/26))
+
 ## 0.1.0-alpha.1
 
 Released 2024-Jun-20


### PR DESCRIPTION
Note: This PR was opened automatically by the [core version update workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/actions/workflows/core-version-update.yml).

Merge once packages are available on NuGet and the build passes.

## Changes

* Sets `OpenTelemetryCoreLatestVersion` in `Common.props` to `1.10.0`.