### PR TITLE
[release] Prepare release Exporter.OneCollector-1.10.0-rc.1

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.10.0-rc.1
+
+Released 2024-Sep-16
+
 ## 1.10.0-alpha.1
 
 Released 2024-Sep-06


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/actions/workflows/prepare-release.yml).

Release request: #32
Requested by: @CodeBlanch

## Changes

* CHANGELOG files updated for projects being released.
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages and push to NuGet [`approvers`, `maintainers`]