### PR TITLE
[release] Prepare release Exporter.OneCollector-1.20.0

### DIFF
--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Shipped.txt
@@ -26,6 +26,10 @@ OpenTelemetry.Exporter.OneCollector.OneCollectorExporterValidationException.OneC
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.get -> string!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventName.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventNamespace.get -> string!
+OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventNamespace.set -> void
+OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.EventFullNameMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>?
+OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.EventFullNameMappings.set -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.OneCollectorLogExporterOptions() -> void
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.SerializationOptions.get -> OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterSerializationOptions!
 OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterSerializationOptions
@@ -39,6 +43,8 @@ OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.ConfigureSerializationO
 OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.ConfigureTransportOptions(System.Action<OpenTelemetry.Exporter.OneCollector.OneCollectorExporterTransportOptions!>! configure) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
 OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetConnectionString(string! connectionString) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
 OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetDefaultEventName(string! defaultEventName) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetDefaultEventNamespace(string! defaultEventNamespace) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
+OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetEventFullNameMappings(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? eventFullNameMappings) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
 OpenTelemetry.Logs.OneCollectorLoggerProviderBuilderExtensions
 OpenTelemetry.Logs.OneCollectorOpenTelemetryLoggerOptionsExtensions
 override sealed OpenTelemetry.Exporter.OneCollector.OneCollectorExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult

--- a/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OneCollector/.publicApi/PublicAPI.Unshipped.txt
@@ -1,6 +1,0 @@
-OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventNamespace.get -> string!
-OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.DefaultEventNamespace.set -> void
-OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.EventFullNameMappings.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>?
-OpenTelemetry.Exporter.OneCollector.OneCollectorLogExporterOptions.EventFullNameMappings.set -> void
-OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetDefaultEventNamespace(string! defaultEventNamespace) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!
-OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder.SetEventFullNameMappings(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? eventFullNameMappings) -> OpenTelemetry.Logs.OneCollectorLogExportProcessorBuilder!

--- a/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OneCollector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.20.0
+
+Released 2024-Sep-28
+
 ## 1.10.0-alpha.1
 
 Released 2024-Sep-06


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/actions/workflows/prepare-release.yml).

Release request: #51
Requested by: @CodeBlanchTest2

## Changes

* CHANGELOG files updated for projects being released.
* Public API files updated for projects being released (only performed for stable releases).
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages and push to NuGet [`approvers`, `maintainers`]